### PR TITLE
Add cli support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+var parseRepo = require('./');
+
+if (!process.argv[2]) {
+  process.stderr.write('Error: URL must be provided as first argument\n');
+  process.exit(1);
+}
+var res = parseRepo(process.argv[2]);
+process.stdout.write(JSON.stringify(res, null, 2) + '\n');

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Diego Guerra <dgoguerra.or@gmail.com>",
   "license": "MIT",
   "homepage": "https://github.com/dgoguerra/parse-repo",
+  "bin": {
+    "parse-repo": "./cli.js"
+  },
   "keywords": [
     "parse",
     "repository",


### PR DESCRIPTION
Add support for using the module as a CLI

```sh
$ npm install -g parse-repo
$ parse-repo https://github.com/jmendiara/parse-repo.git
{
  "remote": "https://github.com/jmendiara/parse-repo.git",
  "protocol": "https",
  "host": "github.com",
  "repository": "jmendiara/parse-repo",
  "owner": "jmendiara",
  "project": "parse-repo"
}
```

